### PR TITLE
Fix - Enforce Primary Key Constraint

### DIFF
--- a/graphql-app/src/test/java/com/dac/graphql/app/DynamicSchemaComponentTest.java
+++ b/graphql-app/src/test/java/com/dac/graphql/app/DynamicSchemaComponentTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.junit.jupiter.api.AfterEach;
 import java.nio.file.*;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -53,7 +54,7 @@ class DynamicSchemaComponentTest {
         mockMvc.perform(multipart("/api/upload-graphql-spec/cat")
                 .file(schemaFile))
                 .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("Schema uploaded and database generated successfully")));
+                .andExpect(content().string(containsString("Schema uploaded and database generated successfully")));
 
         // Now test that the dynamic schema works for the Cat type
         String query = """
@@ -116,6 +117,7 @@ class DynamicSchemaComponentTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.errors").exists());
+                .andExpect(jsonPath("$.errors").exists())
+                .andExpect(jsonPath("$.errors[0].message", containsString("UNIQUE constraint failed")));
     }
 } 

--- a/graphql-app/src/test/java/com/dac/graphql/app/DynamicSchemaComponentTest.java
+++ b/graphql-app/src/test/java/com/dac/graphql/app/DynamicSchemaComponentTest.java
@@ -7,8 +7,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.junit.jupiter.api.AfterEach;
+import java.nio.file.*;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -20,6 +21,11 @@ class DynamicSchemaComponentTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @AfterEach
+    void deleteDatabaseFile() throws Exception {
+        Files.deleteIfExists(Paths.get("database.db"));
+    }
 
     @Test
     void dynamicSchemaAndDataFetchers_workForCat() throws Exception {
@@ -67,5 +73,49 @@ class DynamicSchemaComponentTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.data").exists())
                 .andExpect(jsonPath("$.data.cats").isArray());
+    }
+
+    @Test
+    void primaryKeyConstraint_preventsDuplicateIds() throws Exception {
+        // Upload schema with Bike type
+        String schemaContent = """
+            type Bike {
+              id: ID!
+              model: String!
+            }
+            type Mutation {
+              addBike(id: ID!, model: String!): Bike
+            }
+            type Query {
+              bikes: [Bike!]!
+            }
+            """;
+
+        MockMultipartFile schemaFile = new MockMultipartFile(
+            "file",
+            "bike-schema.graphql",
+            "text/plain",
+            schemaContent.getBytes()
+        );
+
+        mockMvc.perform(multipart("/api/upload-graphql-spec/bike")
+                .file(schemaFile))
+                .andExpect(status().isOk());
+
+        // Insert a bike with id "1"
+        String mutation = "mutation { addBike(id: \"1\", model: \"A\") { id model } }";
+        String json = "{\"query\":\"" + mutation.replace("\"", "\\\"") + "\"}";
+        mockMvc.perform(post("/graphql/bike")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.addBike.id").value("1"));
+
+        // Attempt to insert another bike with the same id "1"
+        mockMvc.perform(post("/graphql/bike")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.errors").exists());
     }
 } 

--- a/graphql-app/src/test/java/com/dac/graphql/app/PostgresTestConfig.java
+++ b/graphql-app/src/test/java/com/dac/graphql/app/PostgresTestConfig.java
@@ -1,6 +1,7 @@
 package com.dac.graphql.app;
 
 import com.dac.graphql.core.adapter.DatabaseAdapter;
+import graphql.language.Type;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -28,7 +29,7 @@ public class PostgresTestConfig {
             @Override
             public void createTable(String tableName, String columns) throws SQLException {}
             @Override
-            public String mapGraphQLTypeToSql(String graphQLType) { return "text"; }
+            public String mapGraphQLTypeToSql(Type<?> graphQLType) { return "text"; }
             @Override
             public String getDatabaseType() { return "postgres"; }
         };

--- a/graphql-core/src/main/java/com/dac/graphql/core/adapter/DatabaseAdapter.java
+++ b/graphql-core/src/main/java/com/dac/graphql/core/adapter/DatabaseAdapter.java
@@ -1,5 +1,7 @@
 package com.dac.graphql.core.adapter;
 
+import graphql.language.Type;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -64,7 +66,7 @@ public interface DatabaseAdapter {
      * @param graphQLType the GraphQL type string
      * @return database-specific SQL type string
      */
-    String mapGraphQLTypeToSql(String graphQLType);
+    String mapGraphQLTypeToSql(Type<?> graphQLType);
     
     /**
      * Get the database type identifier.
@@ -72,4 +74,15 @@ public interface DatabaseAdapter {
      * @return database type (e.g., "sqlite", "postgres")
      */
     String getDatabaseType();
+
+    default String getBaseTypeName(graphql.language.Type<?> type) {
+        if (type instanceof graphql.language.TypeName) {
+            return ((graphql.language.TypeName) type).getName();
+        } else if (type instanceof graphql.language.ListType) {
+            return getBaseTypeName(((graphql.language.ListType) type).getType());
+        } else if (type instanceof graphql.language.NonNullType) {
+            return getBaseTypeName(((graphql.language.NonNullType) type).getType());
+        }
+        return type.toString(); // fallback
+    }
 } 

--- a/graphql-core/src/main/java/com/dac/graphql/core/service/SchemaService.java
+++ b/graphql-core/src/main/java/com/dac/graphql/core/service/SchemaService.java
@@ -29,7 +29,7 @@ public class SchemaService {
         for (ObjectTypeDefinition type : types) {
             if (type.getName().equals("Query") || type.getName().equals("Mutation")) continue;
             String columns = type.getFieldDefinitions().stream()
-                    .map(field -> field.getName() + " " + databaseAdapter.mapGraphQLTypeToSql(field.getType().toString()))
+                    .map(field -> field.getName() + " " + databaseAdapter.mapGraphQLTypeToSql(field.getType()))
                     .collect(Collectors.joining(", "));
             databaseAdapter.createTable(type.getName(), columns);
         }

--- a/graphql-core/src/test/java/com/dac/graphql/core/TestDatabaseAdapterConfig.java
+++ b/graphql-core/src/test/java/com/dac/graphql/core/TestDatabaseAdapterConfig.java
@@ -1,6 +1,7 @@
 package com.dac.graphql.core;
 
 import com.dac.graphql.core.adapter.DatabaseAdapter;
+import graphql.language.Type;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 
@@ -26,7 +27,7 @@ public class TestDatabaseAdapterConfig {
             @Override
             public void createTable(String tableName, String columns) { }
             @Override
-            public String mapGraphQLTypeToSql(String graphQLType) { return "TEXT"; }
+            public String mapGraphQLTypeToSql(Type<?> graphQLType) { return "TEXT"; }
             @Override
             public String getDatabaseType() { return "test"; }
         };

--- a/graphql-core/src/test/java/com/dac/graphql/core/service/SchemaServiceTest.java
+++ b/graphql-core/src/test/java/com/dac/graphql/core/service/SchemaServiceTest.java
@@ -1,5 +1,6 @@
 package com.dac.graphql.core.service;
 
+import graphql.language.Type;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class SchemaServiceTest {
                 assertTrue(columns.contains("title"));
                 assertTrue(columns.contains("author"));
             }
-            @Override public String mapGraphQLTypeToSql(String graphQLType) { return "TEXT"; }
+            @Override public String mapGraphQLTypeToSql(Type<?> graphQLType) { return "TEXT"; }
             @Override public String getDatabaseType() { return "test"; }
         });
     }

--- a/postgres-adapter/src/main/java/com/dac/graphql/postgres/PostgresAdapter.java
+++ b/postgres-adapter/src/main/java/com/dac/graphql/postgres/PostgresAdapter.java
@@ -10,6 +10,7 @@ import java.util.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import javax.sql.DataSource;
+import graphql.language.Type;
 
 @Component
 @Profile("postgres")
@@ -110,12 +111,13 @@ public class PostgresAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String mapGraphQLTypeToSql(String graphQLType) {
-        switch (graphQLType.replace("!", "")) {
+    public String mapGraphQLTypeToSql(Type<?> graphQLType) {
+        String baseType = getBaseTypeName(graphQLType);
+        switch (baseType) {
             case "Int": return "INTEGER";
             case "Float": return "DOUBLE PRECISION";
             case "Boolean": return "BOOLEAN";
-            case "ID": return "SERIAL PRIMARY KEY";
+            case "ID": return "TEXT PRIMARY KEY";
             case "String":
             default: return "TEXT";
         }

--- a/postgres-adapter/src/test/java/com/dac/graphql/postgres/PostgresAdapterTest.java
+++ b/postgres-adapter/src/test/java/com/dac/graphql/postgres/PostgresAdapterTest.java
@@ -3,6 +3,7 @@ package com.dac.graphql.postgres;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import graphql.language.TypeName;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -36,11 +37,11 @@ class PostgresAdapterTest {
 
     @Test
     void testMapGraphQLTypeToSql() {
-        assertEquals("TEXT", adapter.mapGraphQLTypeToSql("String"));
-        assertEquals("INTEGER", adapter.mapGraphQLTypeToSql("Int"));
-        assertEquals("DOUBLE PRECISION", adapter.mapGraphQLTypeToSql("Float"));
-        assertEquals("BOOLEAN", adapter.mapGraphQLTypeToSql("Boolean"));
-        assertEquals("SERIAL PRIMARY KEY", adapter.mapGraphQLTypeToSql("ID"));
+        assertEquals("TEXT", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("String").build()));
+        assertEquals("INTEGER", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Int").build()));
+        assertEquals("DOUBLE PRECISION", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Float").build()));
+        assertEquals("BOOLEAN", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Boolean").build()));
+        assertEquals("TEXT PRIMARY KEY", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("ID").build()));
     }
 
     @Test

--- a/sqlite-adapter/src/main/java/com/dac/graphql/sqlite/SqliteAdapter.java
+++ b/sqlite-adapter/src/main/java/com/dac/graphql/sqlite/SqliteAdapter.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.sql.*;
 import java.util.*;
+import graphql.language.Type;
 
 @Component
 @Primary
@@ -98,8 +99,9 @@ public class SqliteAdapter implements DatabaseAdapter {
     }
 
     @Override
-    public String mapGraphQLTypeToSql(String graphQLType) {
-        switch (graphQLType.replace("!", "")) {
+    public String mapGraphQLTypeToSql(Type<?> graphQLType) {
+        String baseType = getBaseTypeName(graphQLType);
+        switch (baseType) {
             case "Int": return "INTEGER";
             case "Float": return "REAL";
             case "Boolean": return "BOOLEAN";

--- a/sqlite-adapter/src/test/java/com/dac/graphql/sqlite/SqliteAdapterTest.java
+++ b/sqlite-adapter/src/test/java/com/dac/graphql/sqlite/SqliteAdapterTest.java
@@ -3,6 +3,7 @@ package com.dac.graphql.sqlite;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import graphql.language.TypeName;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -31,12 +32,12 @@ class SqliteAdapterTest {
 
     @Test
     void testMapGraphQLTypeToSql() {
-        assertEquals("INTEGER", adapter.mapGraphQLTypeToSql("Int"));
-        assertEquals("REAL", adapter.mapGraphQLTypeToSql("Float"));
-        assertEquals("BOOLEAN", adapter.mapGraphQLTypeToSql("Boolean"));
-        assertEquals("TEXT PRIMARY KEY", adapter.mapGraphQLTypeToSql("ID"));
-        assertEquals("TEXT", adapter.mapGraphQLTypeToSql("String"));
-        assertEquals("TEXT", adapter.mapGraphQLTypeToSql("CustomType"));
+        assertEquals("INTEGER", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Int").build()));
+        assertEquals("REAL", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Float").build()));
+        assertEquals("BOOLEAN", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("Boolean").build()));
+        assertEquals("TEXT PRIMARY KEY", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("ID").build()));
+        assertEquals("TEXT", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("String").build()));
+        assertEquals("TEXT", adapter.mapGraphQLTypeToSql(TypeName.newTypeName("CustomType").build()));
     }
 
     @Test


### PR DESCRIPTION
**Effort:** 3 Hours

**Issue Description:**

Both SQLite & Postgres allowed inserting data with duplicate ID.

<img width="902" height="682" alt="Screenshot 2025-07-19 at 10 24 23 PM" src="https://github.com/user-attachments/assets/e3d5e40a-809d-4648-bf76-15236d63d4e6" />


**Root Cause**

The method mapGraphQLTypeToSql was always returning "TEXT" for the id field (and all fields), instead of "TEXT PRIMARY KEY" for ID!, because it was using the string representation of the GraphQL type AST node (e.g., "NonNullType{type=TypeName{name='ID'}}")


**Build Status Post Fix:**

<img width="1276" height="383" alt="image" src="https://github.com/user-attachments/assets/650f4fa3-d029-4a10-9e8e-80c47a58df51" />



**Local Testing Post Fix**

<img width="900" height="685" alt="image" src="https://github.com/user-attachments/assets/f8f995b4-1c0a-4d70-b23f-cc56b90f21a9" />

